### PR TITLE
Fix/138

### DIFF
--- a/js/components/interface/foregroundControls/ForegroundControls.js
+++ b/js/components/interface/foregroundControls/ForegroundControls.js
@@ -42,7 +42,7 @@ define(function (require) {
       var tutorialBtn = GEPPETTO.Tutorial != undefined ? React.createFactory(TutorialButton)({}) : '';
 
 
-      return <div className={'foreground-controls'}>
+      return <div id="foreground-toolbar" className={'foreground-controls'}>
         {controlPanelBtn}
         <br/>
         {spotlightBtn}

--- a/js/components/interface/foregroundControls/ForegroundControls.less
+++ b/js/components/interface/foregroundControls/ForegroundControls.less
@@ -1,6 +1,6 @@
 #foreground-toolbar {
     position: fixed;
-    left: 52px;
+    left: 37px;
     top: 320px;
 }
 

--- a/js/components/interface/simulationControls/ExperimentControls.js
+++ b/js/components/interface/simulationControls/ExperimentControls.js
@@ -158,7 +158,7 @@ define(function (require) {
       }
 
       return (
-        <div className="simulation-controls">
+        <div id="sim-toolbar" className="simulation-controls">
           <HelpButton disabled={false} hidden={this.props.hideHelp}/>
           <StopButton disabled={this.state.disableStop} hidden={this.props.hideStop}/>
           <PauseButton disabled={this.state.disablePause} hidden={this.props.hidePause}/>


### PR DESCRIPTION
without this the foregroundcontrols (control panel etc buttons) and experimentcontrols (run play stop etc) do not render properly because they don't have the right attributes for css to apply. 
additional css change aligns foregroundcontrols with canvas control buttons.

- [ ] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
- [ ] Make sure both push and pr travis builds are passing before asking for a review
