### PR TITLE
Add custom image during loading of the geppetto application

### DIFF
--- a/js/components/widgets/stackViewer/StackViewerComponent.js
+++ b/js/components/widgets/stackViewer/StackViewerComponent.js
@@ -468,7 +468,7 @@ define(function (require) {
                   for (j in list) {
                     objects = objects + list[j] + '\n';
                   }
-                  if (objects !== '') {
+                  if (objects !== '' && index == 0) {
                     that.setHoverText(callX,callY,objects);
                   }
                 }
@@ -486,6 +486,7 @@ define(function (require) {
             });
           })(i, that);
         });
+        that.state.loadingLabels = false;
       }
     },
 

--- a/js/components/widgets/stackViewer/StackViewerComponent.js
+++ b/js/components/widgets/stackViewer/StackViewerComponent.js
@@ -443,18 +443,21 @@ define(function (require) {
               success: function (data) {
                 result = data.trim().split(':')[1].trim().split(' ');
                 if (result !== '') {
-                  for (j in result) {
-                    if (result[j].trim() !== '') {
-                      var index = Number(result[j]);
-                      if (i !== 0 || index !== 0) { // don't select template
-                        if (index == 0) {
-                          if (!shift) {
-                            that.state.objects.push(that.state.label[i]);
-                          }
-                        } else {
-                          if (typeof that.props.templateDomainIds !== 'undefined' && typeof that.props.templateDomainNames !== 'undefined' && typeof that.props.templateDomainIds[index] !== 'undefined' && typeof that.props.templateDomainNames[index] !== 'undefined' && that.props.templateDomainNames[index] !== null) {
-                            that.state.objects.push(that.props.templateDomainNames[index]);
-                            break;
+                  var currentPosition = that.renderer.plugins.interaction.mouse.getLocalPosition(that.stack);
+                  if (callX == currentPosition.x.toFixed(0) && callY == currentPosition.y.toFixed(0)) {
+                    for (j in result) {
+                      if (result[j].trim() !== '') {
+                        var index = Number(result[j]);
+                        if (i !== 0 || index !== 0) { // don't select template
+                          if (index == 0) {
+                            if (!shift) {
+                              that.state.objects.push(that.state.label[i]);
+                            }
+                          } else {
+                            if (typeof that.props.templateDomainIds !== 'undefined' && typeof that.props.templateDomainNames !== 'undefined' && typeof that.props.templateDomainIds[index] !== 'undefined' && typeof that.props.templateDomainNames[index] !== 'undefined' && that.props.templateDomainNames[index] !== null) {
+                              that.state.objects.push(that.props.templateDomainNames[index]);
+                              break;
+                            }
                           }
                         }
                       }
@@ -486,7 +489,6 @@ define(function (require) {
             });
           })(i, that);
         });
-        that.state.loadingLabels = false;
       }
     },
 

--- a/js/pages/geppetto/geppetto.ejs
+++ b/js/pages/geppetto/geppetto.ejs
@@ -31,7 +31,7 @@
 	<% } %>
 	    
 </head>
-<body>
+<body style="margin: 0px">
 
 <!-- For index purposes -->
 <div style="display:none" id="content">
@@ -45,7 +45,10 @@ $content
 
 
 <div id="mainContainer">
-	<div id="loadingText" style="text-align:center; font-family: consolas; margin-top: 50px;} ">LOADING... [~3MB]</div>
+	<div id="loadingText" style="display:grid; height: '100%'; text-align:center; font-family: consolas;">
+		<img src="geppetto/build/splash.png" style="max-width: 101%;max-height: 100; margin-top: -9px;margin-left: -8px;" alt="" onerror='document.getElementById("loadingMessage").style.display="block"' >
+		<span id="loadingMessage" style="display : none; margin-top: 50px" >LOADING... [~3MB]</span>
+	</div>
     <div id="controls" class="noSelection">
 		<div id="DownloadProjectButton" class="row"></div>
         <div id="SaveButton" class="row"></div>

--- a/js/pages/geppetto/geppetto.ejs
+++ b/js/pages/geppetto/geppetto.ejs
@@ -45,8 +45,8 @@ $content
 
 
 <div id="mainContainer">
-	<div id="loadingText" style="display:grid; height: '100%'; text-align:center; font-family: consolas;">
-		<img src="geppetto/build/splash.png" style="max-width: 101%;max-height: 100; margin-top: -9px;margin-left: -8px;" alt="" onerror='document.getElementById("loadingMessage").style.display="block"' >
+	<div id="loadingText" style="font-family: consolas;margin: 0px;">
+		<img src="geppetto/build/splash.png" style="max-width: 90%;margin: 0px;position: absolute;display: inline-block;text-align: center;vertical-align: middle;top: 2%;left: 5%;" alt="" onerror='document.getElementById("loadingMessage").style.display="block"' >
 		<span id="loadingMessage" style="display : none; margin-top: 50px" >LOADING... [~3MB]</span>
 	</div>
     <div id="controls" class="noSelection">


### PR DESCRIPTION
- Custom image can be placed in the webapp/images/splash.png
- the custom image will replace the text "LOADING... [~3MB]" and displayed instead of it during the load.

This is just an extension of Jesus' branch but based on the latest development, so I opened a new branch from my local development.