### PR TITLE
Frontend websocket reconnection

### DIFF
--- a/js/common/GEPPETTO.Resources.js
+++ b/js/common/GEPPETTO.Resources.js
@@ -104,6 +104,8 @@ export default function (GEPPETTO) {
       RECONNECTING: 2,
     },
 
+    RECONNECTION_ERROR: "The client was not able to reconnect to the Backend, the page will be reloaded.",
+
     PROJECT_LOADED: "Project loaded",
 
     MODEL_LOADED: "The model for the current project has been loaded",

--- a/js/common/GEPPETTO.Resources.js
+++ b/js/common/GEPPETTO.Resources.js
@@ -98,6 +98,12 @@ export default function (GEPPETTO) {
       GHOST: .3,
     },
 
+    SocketStatus: {
+      CLOSE: 0,
+      OPEN: 1,
+      RECONNECTING: 2,
+    },
+
     PROJECT_LOADED: "Project loaded",
 
     MODEL_LOADED: "The model for the current project has been loaded",
@@ -333,6 +339,8 @@ export default function (GEPPETTO) {
     SIMULATOR_UNAVAILABLE: " is Unavailable",
 
     WEBSOCKET_CONNECTION_ERROR: "Server Connection Error",
+
+    WEBSOCKET_RECONNECTION: "Client is attempting to reconnect",
 
     STOP_SIMULATION_TUTORIAL: "Tutorial Starting",
 

--- a/js/communication/GEPPETTO.GlobalHandler.js
+++ b/js/communication/GEPPETTO.GlobalHandler.js
@@ -18,7 +18,8 @@ function GlobalHandler (GEPPETTO) {
           DATASOURCE_FETCHED: "data_source_results_fetched",
           SERVER_AVAILABLE: "server_available",
           SERVER_UNAVAILABLE: "server_unavailable",
-          USER_PRIVILEGES : "user_privileges"
+          USER_PRIVILEGES : "user_privileges",
+          RECONNECTION_ERROR: "reconnection_error"
         };
 
   var messageHandler
@@ -28,7 +29,7 @@ function GlobalHandler (GEPPETTO) {
   messageHandler[messageTypes.CLIENT_ID] = function (payload) {
     GEPPETTO.MessageSocket.setClientID(payload.clientID);
   };
-        
+
   messageHandler[messageTypes.USER_PRIVILEGES] = function (payload) {
     var user_privileges = JSON.parse(payload.user_privileges);
     GEPPETTO.UserController.setUserPrivileges(user_privileges);
@@ -86,7 +87,7 @@ function GlobalHandler (GEPPETTO) {
   messageHandler[messageTypes.SCRIPT_FETCHED] = function (payload) {
     GEPPETTO.ScriptRunner.runScript(payload.script_fetched);
   };
-        
+
   messageHandler[messageTypes.DATASOURCE_FETCHED] = function (payload) {
     var message = JSON.parse(payload.data_source_results_fetched);
     GEPPETTO.Spotlight.updateDataSourceResults(message.data_source_name,JSON.parse(message.results));
@@ -96,6 +97,13 @@ function GlobalHandler (GEPPETTO) {
   messageHandler[messageTypes.SERVER_AVAILABLE] = function (payload) {
     GEPPETTO.ModalFactory.infoDialog(GEPPETTO.Resources.SERVER_AVAILABLE, payload.message);
     GEPPETTO.trigger(GEPPETTO.Events.Hide_spinner);
+  };
+
+  messageHandler[messageTypes.RECONNECTION_ERROR] = function (payload) {
+    GEPPETTO.ModalFactory.infoDialog(GEPPETTO.Resources.RECONNECTION_ERROR, payload.message);
+    GEPPETTO.MessageSocket.SocketStatus = GEPPETTO.Resources.SocketStatus.CLOSE;
+    GEPPETTO.trigger(GEPPETTO.Events.Hide_spinner);
+    GEPPETTO.trigger(GEPPETTO.Events.Websocket_disconnected);
   };
 
   GEPPETTO.GlobalHandler

--- a/js/communication/MessageHandler.js
+++ b/js/communication/MessageHandler.js
@@ -51,13 +51,8 @@ function MessageHandler (GEPPETTO) {
 
   messageHandler[messageTypes.PROJECT_LOADED] = function (payload) {
     var message = JSON.parse(payload.project_loaded);
-    if (GEPPETTO.MessageSocket.projectId === undefined) {
-      GEPPETTO.MessageSocket.projectId = message.project.id;
-      GEPPETTO.Manager.loadProject(message.project, message.persisted);
-    } else {
-      console.log("Project reloaded after reconnection.");
-      GEPPETTO.trigger(GEPPETTO.Events.Hide_spinner);
-    }
+    GEPPETTO.MessageSocket.projectId = message.project.id;
+    GEPPETTO.Manager.loadProject(message.project, message.persisted);
   };
 
   messageHandler[messageTypes.GET_DROPBOX_TOKEN] = function (payload) {

--- a/js/communication/MessageHandler.js
+++ b/js/communication/MessageHandler.js
@@ -51,7 +51,13 @@ function MessageHandler (GEPPETTO) {
 
   messageHandler[messageTypes.PROJECT_LOADED] = function (payload) {
     var message = JSON.parse(payload.project_loaded);
-    GEPPETTO.Manager.loadProject(message.project, message.persisted);
+    if (GEPPETTO.MessageSocket.projectId === undefined) {
+      GEPPETTO.MessageSocket.projectId = message.project.id;
+      GEPPETTO.Manager.loadProject(message.project, message.persisted);
+    } else {
+      console.log("Project reloaded after reconnection.");
+      GEPPETTO.trigger(GEPPETTO.Events.Hide_spinner);
+    }
   };
 
   messageHandler[messageTypes.GET_DROPBOX_TOKEN] = function (payload) {
@@ -279,5 +285,3 @@ function MessageHandler (GEPPETTO) {
 // Compatibility with new imports and old require syntax
 MessageHandler.default = MessageHandler;
 module.exports = MessageHandler;
-
-

--- a/js/communication/MessageSocket.js
+++ b/js/communication/MessageSocket.js
@@ -130,7 +130,6 @@ define(function (require) {
             case 'ECONNREFUSED':
               console.log("%c WebSocket Status - Open connection error ", 'background: #000; color: red');
               GEPPETTO.CommandController.log(GEPPETTO.Resources.WEBSOCKET_CONNECTION_ERROR, true);
-              // GEPPETTO.MessageSocket.reconnect(e);
               break;
             case undefined:
               console.log("%c WebSocket Status - Open connection error ", 'background: #000; color: red');


### PR DESCRIPTION
# Frontend websocket reconnection

The core of the changes on this side goes in the MessageSocket module.
In here we are now detecting when the connection is closed abnormally, and in that case calling the reconnect function that handles the logic to reopen the websocket every 5 seconds (by default) per number of attempts (10 by defaults). These values can be tweaked by the user by calling GEPPETTO.MessageSocket.reconnectionLimit & GEPPETTO.MessageSocket. autoReconnectInterval (number of milliseconds, at the moment is 5*1000).

This address #177 
This goes along with https://github.com/openworm/org.geppetto.frontend/pull/902
