### PR TITLE
Feature/204

### DIFF
--- a/js/components/interface/3dCanvas/Canvas.js
+++ b/js/components/interface/3dCanvas/Canvas.js
@@ -60,7 +60,8 @@ define(function (require) {
       }
       if (added.length > 0) {
         this.engine.updateSceneWithNewInstances(added);
-        GEPPETTO.trigger(GEPPETTO.Events.Reset_camera);
+        // Trigger Update_camera event, camera position is reset when project is first loaded with initial instances
+        GEPPETTO.trigger(GEPPETTO.Events.Update_camera);
         this.setDirty(true);
       }
 
@@ -765,7 +766,7 @@ define(function (require) {
       GEPPETTO.WidgetsListener.unsubscribe(this.engine);
       GEPPETTO.off(GEPPETTO.Events.Instances_created, null, this);
       GEPPETTO.off(GEPPETTO.Events.Instance_deleted, null, this);
-      GEPPETTO.off(GEPPETTO.Events.Reset_camera, null, this);
+      GEPPETTO.off(GEPPETTO.Events.Update_camera, null, this);
     }
 
     componentDidMount () {
@@ -794,13 +795,21 @@ define(function (require) {
           that.engine.setSize(width, height);
         }, false);
         
-        GEPPETTO.on(GEPPETTO.Events.Reset_camera, () => {
+        /*
+         * Update camera position call.
+         */
+        GEPPETTO.on(GEPPETTO.Events.Update_camera, () => {
           let instancesFetched = window.Instances.length;
+          // Instances fetched were stored in window.Instances variable, get number of those with visual capability. 
           for ( var i = 0; i < window.Instances.length ; i++ ){
             if ( !window.Instances[i].hasCapability('VisualCapability') ){
               instancesFetched--;
             }
           }
+          /*
+           * Reset camera call, only done once after instances are rendered. Needed to position camera after initial loading
+           * instead of resetting the camera every time something is added to the Canvas.
+           */
           if ( instancesFetched === Object.keys(this.engine.meshes).length && this.initialCameraReset){
             this.resetCamera();
             this.initialCameraReset = false;

--- a/js/components/interface/3dCanvas/Canvas.js
+++ b/js/components/interface/3dCanvas/Canvas.js
@@ -34,7 +34,8 @@ define(function (require) {
         },
         instances: []
       }
-
+      
+      this.initialCameraReset = false;
     }
 
     /**
@@ -59,6 +60,7 @@ define(function (require) {
       }
       if (added.length > 0) {
         this.engine.updateSceneWithNewInstances(added);
+        GEPPETTO.trigger(GEPPETTO.Events.Reset_camera);
         this.setDirty(true);
       }
 
@@ -763,6 +765,7 @@ define(function (require) {
       GEPPETTO.WidgetsListener.unsubscribe(this.engine);
       GEPPETTO.off(GEPPETTO.Events.Instances_created, null, this);
       GEPPETTO.off(GEPPETTO.Events.Instance_deleted, null, this);
+      GEPPETTO.off(GEPPETTO.Events.Reset_camera, null, this);
     }
 
     componentDidMount () {
@@ -790,7 +793,21 @@ define(function (require) {
           var [width, height] = that.setContainerDimensions();
           that.engine.setSize(width, height);
         }, false);
-
+        
+        GEPPETTO.on(GEPPETTO.Events.Reset_camera, () => {
+          let instancesFetched = window.Instances.length;
+          for ( var i = 0; i < window.Instances.length ; i++ ){
+            if ( !window.Instances[i].hasCapability('VisualCapability') ){
+              instancesFetched--;
+            }
+          }
+          if ( instancesFetched === Object.keys(this.engine.meshes).length && this.initialCameraReset){
+            this.resetCamera();
+            this.initialCameraReset = false;
+          }
+        }, this);
+        
+        this.initialCameraReset = true;
       }
     }
 

--- a/js/components/interface/3dCanvas/ThreeDEngine.js
+++ b/js/components/interface/3dCanvas/ThreeDEngine.js
@@ -637,7 +637,6 @@ define(['jquery'], function () {
       if (traversedInstances.length > 0) {
         this.setAllGeometriesType(this.getDefaultGeometryType());
         this.scene.updateMatrixWorld(true);
-        this.resetCamera();
       }
     },
 

--- a/js/pages/geppetto/GEPPETTO.Events.js
+++ b/js/pages/geppetto/GEPPETTO.Events.js
@@ -65,7 +65,7 @@ export default function (GEPPETTO) {
     Receive_Python_Message: "receive_python_message",
     Websocket_disconnected : "websocket_disconnected",
     Error_while_exec_python_command: "error_while_exec_python_command",
-    Reset_camera : "reset_camera",
+    Update_camera : "update_camera",
 
     listen: function () {
       GEPPETTO.on(this.Select, function () {

--- a/js/pages/geppetto/GEPPETTO.Events.js
+++ b/js/pages/geppetto/GEPPETTO.Events.js
@@ -65,6 +65,7 @@ export default function (GEPPETTO) {
     Receive_Python_Message: "receive_python_message",
     Websocket_disconnected : "websocket_disconnected",
     Error_while_exec_python_command: "error_while_exec_python_command",
+    Reset_camera : "reset_camera",
 
     listen: function () {
       GEPPETTO.on(this.Select, function () {


### PR DESCRIPTION
Takes care of issue #204 . Instead of resetting the camera every time a new instance is added to the camera, the camera is only reset once on canvas load and rendering of initial variables.