### PR TITLE
Resolve empty thumbnail crash

### DIFF
--- a/js/components/interface/controlPanel/controlpanel.js
+++ b/js/components/interface/controlPanel/controlpanel.js
@@ -40,6 +40,12 @@ define(function (require) {
     },
 
     render: function () {
+      if (this.props.data == undefined) {
+        return (
+          <div>
+          </div>
+        )
+      }
       var imgId = this.props.rowData.path.replace(/\./g, '_') + "_thumbnail";
       var titleValue = "<img src='" + this.props.data + "' class='thumbnail-img-tooltip'/>";
 


### PR DESCRIPTION
Resolves this error:
```
Cannot read property 'indexOf' of undefined

TypeError: Cannot read property 'indexOf' of undefined
    at Object.render (webpack:///./node_modules/@geppettoengine/geppetto-client/js/components/interface/controlPanel/controlpanel.js?:63:27)
    at finishClassComponent (webpack:///./node_modules/react-dom/cjs/react-dom.development.js?:17160:31)
    at updateClassComponent (webpack:///./node_modules/react-dom/cjs/react-dom.development.js?:17110:24)
    at beginWork (webpack:///./node_modules/react-dom/cjs/react-dom.development.js?:18620:16)
    at HTMLUnknownElement.callCallback (webpack:///./node_modules/react-dom/cjs/react-dom.development.js?:188:14)
    at Object.invokeGuardedCallbackDev (webpack:///./node_modules/react-dom/cjs/react-dom.development.js?:237:16)
    at invokeGuardedCallback (webpack:///./node_modules/react-dom/cjs/react-dom.development.js?:292:31)
    at beginWork$1 (webpack:///./node_modules/react-dom/cjs/react-dom.development.js?:23203:7)
    at performUnitOfWork (webpack:///./node_modules/react-dom/cjs/react-dom.development.js?:22154:12)
    at workLoopSync (webpack:///./node_modules/react-dom/cjs/react-dom.development.js?:22130:22)
```

- [N/A*] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
- [ ] Make sure both push and pr travis builds are passing before asking for a review

*Not a usual state for the system to be in a just handling a potential edge case so casper test would require a lot of work to simulate and would be overkill.