### PR TITLE
#232 onLoad method for canvas plus small improvements to animation

### DIFF
--- a/js/components/interface/3dCanvas/ThreeDEngine.js
+++ b/js/components/interface/3dCanvas/ThreeDEngine.js
@@ -64,6 +64,7 @@ define(['jquery'], function () {
       this.needsUpdate = false;
       this.pickingEnabled = true; // flag to enable disable 3d picking
       this.linesUserInput = false;
+      this.animationRunning = true;
       this.linesUserPreference = undefined;
       this.hoverListeners = undefined;
       this.THREE = THREE;
@@ -1534,6 +1535,9 @@ define(['jquery'], function () {
       var that = this;
       that.debugUpdate = that.needsUpdate;
       // so that we log only the cycles when we are updating the scene
+      if (!this.animationRunning) {
+        return;
+      }
 
       that.controls.update();
 

--- a/js/geppettoModel/ModelFactory.js
+++ b/js/geppettoModel/ModelFactory.js
@@ -1334,7 +1334,15 @@ export default function (GEPPETTO) {
           window[topInstances[k].getId()] = topInstances[k];
           window.Instances[topInstances[k].getId()] = topInstances[k];
         }
-        // TODO Should we trigger that instances were added?
+
+        newInstancesPaths.map(newInstance => {
+          if (newInstance !== "time") {
+            let instanceStrings = newInstance.split(".");
+            if (window.Instances[instanceStrings[0]][instanceStrings[1]] !== undefined) {
+              GEPPETTO.trigger(GEPPETTO.Events.Instance_added, newInstance);
+            }
+          }
+        });
       },
 
       /**
@@ -3025,4 +3033,3 @@ function createInstancePathObj (instance) {
     static: true
   };
 }
-

--- a/js/geppettoModel/ModelFactory.js
+++ b/js/geppettoModel/ModelFactory.js
@@ -1335,14 +1335,15 @@ export default function (GEPPETTO) {
           window.Instances[topInstances[k].getId()] = topInstances[k];
         }
 
-        newInstancesPaths.map(newInstance => {
+        for (let instanceCounter = 0; instanceCounter < newInstancesPaths.length; instanceCounter++) {
+          var newInstance = newInstancesPaths[instanceCounter];
           if (newInstance !== "time") {
             let instanceStrings = newInstance.split(".");
             if (window.Instances[instanceStrings[0]][instanceStrings[1]] !== undefined) {
               GEPPETTO.trigger(GEPPETTO.Events.Instance_added, newInstance);
             }
           }
-        });
+        }
       },
 
       /**

--- a/js/pages/geppetto/GEPPETTO.Events.js
+++ b/js/pages/geppetto/GEPPETTO.Events.js
@@ -43,6 +43,7 @@ export default function (GEPPETTO) {
     Spotlight_loaded: "spotlight:loaded",
     Instance_deleted: "instance:deleted",
     Instances_created: "instances:created",
+    Instance_added: "instance:added",
     Show_Tutorial: "show_tutorial",
     Hide_Tutorial: "hide_tutorial",
     Show_spinner: "spinner:show",


### PR DESCRIPTION
This branch originally has been created to create an onLoad method that notify the application when something has been added to the Canvas and StackViewerComponent.
After deeper analysis the problem got confined to the canvas since we are using an interface for the stack viewer in the adaptation to react and I handled this problem there.
For this purpose I:

- added an onLoad prop to the canvas component the gets called after the displayInstance call notifying the user that the new instance has been loaded.
- added a new GEPPETTO event instance_added since the event instances_created does not notify me when a meta instance has been created and also because this event it's heavily bounded to the visual capability and, with the time allocated, was too difficult to modify instances_created. Instance_added gets called when a new instance is created and also gives to the event listener the full path of the instance created.
- Furthermore, the canvas component has a new prop minimiseAnimation that, if enabled, minimise the animate function workload since this function was working all the time.
This has been refactored to allow the canvas to detect when the mouse component is going in and out and turning on/off the animation (since the user can rotate, select and do other stuff).
Also, relying on the new event update_camera created recently I am enabling the animation again when that event gets called, since a new instances has been added, and stopping the animation on select/deselect events listeners since that determine the end of the new instance created.
If the prop is not provided or set to false the animation works as before, differently if this is enabled to true what described above will apply, reducing the load of this in your whole application (that was the goal for VFB).