### PR TITLE
#263 Fix python controlled capability calling setState on unMounted c…

### DIFF
--- a/js/communication/geppettoJupyter/PythonControlledCapability.js
+++ b/js/communication/geppettoJupyter/PythonControlledCapability.js
@@ -274,8 +274,8 @@ define(function (require) {
             wrappedComponentProps['onChange'] = this.handleChange;
             wrappedComponentProps.value = (typeof this.state.value === 'object' && this.state.value !== null && !Array.isArray(this.state.value)) ? JSON.stringify(this.state.value) : this.state.value;
             // Fix case with multiple values: need to set an empty list in case the value is undefined
-            wrappedComponentProps.value = (wrappedComponentProps.multiple && 
-              wrappedComponentProps.value !== undefined 
+            wrappedComponentProps.value = (wrappedComponentProps.multiple 
+              && wrappedComponentProps.value !== undefined 
               && !wrappedComponentProps.value) ? [] : wrappedComponentProps.value;
             delete wrappedComponentProps.searchText;
             delete wrappedComponentProps.dataSource;
@@ -377,10 +377,12 @@ define(function (require) {
 
         callPythonMethod = value => {
           Utils.evalPythonMessage(this.props.method, []).then(response => {
-            if (Object.keys(response).length != 0) {
-              this.setState({ pythonData: response });
-            } else {
-              this.setState({ pythonData: [] });
+            if (this._isMounted) {
+              if (Object.keys(response).length != 0) {
+                this.setState({ pythonData: response });
+              } else {
+                this.setState({ pythonData: [] });
+              }
             }
           });
         }
@@ -435,7 +437,7 @@ define(function (require) {
     },
   }
 })
-function getNameFromWrappedComponent(WrappedComponent) {
+function getNameFromWrappedComponent (WrappedComponent) {
   return WrappedComponent.name || WrappedComponent.Naked.render.name;
 }
 


### PR DESCRIPTION
Sometimes setState is called after fetching a list of items for a selectField with a pythonControlledComponent but the component is not longer mounted causing an error message in the console