### PR TITLE
#269 Add DisplayName to pythonControlledCapability

### DIFF
--- a/js/communication/geppettoJupyter/PythonControlledCapability.js
+++ b/js/communication/geppettoJupyter/PythonControlledCapability.js
@@ -438,6 +438,6 @@ define(function (require) {
   }
 })
 function getNameFromWrappedComponent (WrappedComponent) {
-  return WrappedComponent.name || WrappedComponent.Naked.render.name;
+  return WrappedComponent.name || WrappedComponent.displayName || WrappedComponent.Naked.render.name;
 }
 


### PR DESCRIPTION
Error when trying to wrap components with `withStyles`

Closes #269 