### PR TITLE
#274 uppercase typo in the socketStatus

### DIFF
--- a/js/communication/GEPPETTO.GlobalHandler.js
+++ b/js/communication/GEPPETTO.GlobalHandler.js
@@ -101,7 +101,7 @@ function GlobalHandler (GEPPETTO) {
 
   messageHandler[messageTypes.RECONNECTION_ERROR] = function (payload) {
     GEPPETTO.ModalFactory.infoDialog(GEPPETTO.Resources.RECONNECTION_ERROR, payload.message);
-    GEPPETTO.MessageSocket.SocketStatus = GEPPETTO.Resources.SocketStatus.CLOSE;
+    GEPPETTO.MessageSocket.socketStatus = GEPPETTO.Resources.SocketStatus.CLOSE;
     GEPPETTO.trigger(GEPPETTO.Events.Hide_spinner);
     GEPPETTO.trigger(GEPPETTO.Events.Websocket_disconnected);
   };


### PR DESCRIPTION
Simple typo in the message handler, the socketStatus was set using the Uppercase SocketStatus, on the application side (vfb) we are checking this to see the socketStatus to handle the application reload.
