### PR TITLE
#285 Disable chrome redux-dev-tool integration for listViewer

### DIFF
--- a/js/components/interface/listViewer/ListViewer.js
+++ b/js/components/interface/listViewer/ListViewer.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import Griddle, { plugins, ColumnDefinition, RowDefinition } from 'griddle-react';
+import { plugins, ColumnDefinition, RowDefinition } from 'griddle-react';
+import Griddle from './utils/Griddle'
 import BaseIconComponent from './BaseIconComponent';
 
 import PopupColorPicker from './PopupColorPicker';

--- a/js/components/interface/listViewer/utils/Griddle.js
+++ b/js/components/interface/listViewer/utils/Griddle.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import {
+  createStore,
+  applyMiddleware,
+  compose
+} from 'redux';
+
+import Griddle, { plugins } from 'griddle-react';
+
+import init from 'griddle-react/dist/module/utils/initializer';
+
+const { CorePlugin: corePlugin } = plugins
+
+class GriddleNoReduxBrowserExtension extends Griddle {
+
+  constructor (props) {
+    super(props);
+
+    const { core = corePlugin, storeKey = GriddleNoReduxBrowserExtension.storeKey || 'store' } = props;
+
+    const { initialState, reducer, reduxMiddleware } = init.call(this, core);
+
+    this.store = createStore(
+      reducer,
+      initialState,
+      compose(applyMiddleware(...reduxMiddleware))
+    );
+  }
+}
+
+GriddleNoReduxBrowserExtension.storeKey = 'store';
+
+export default GriddleNoReduxBrowserExtension;


### PR DESCRIPTION
This removes the redux-dev-tool chrome extension from griddle. What do you think @filippomc? Seems to be working fine in the current project we are working on. I was a little exceptic but I was not able to find any broken behaviour. 
(Will start to work with this branch because I'm not able to debug the redux store without it)