### PR TITLE
Fix to avoid slick() component be created more than once

### DIFF
--- a/geppetto-client/js/components/interface/query/customComponents/slideshowImageComponent.js
+++ b/geppetto-client/js/components/interface/query/customComponents/slideshowImageComponent.js
@@ -114,7 +114,7 @@ define(function (require) {
       // apply carousel
       if (this.isCarousel) {
         var slickDivElement = $('#' + this.imageContainerId + '.slickdiv');
-        slickDivElement.slick();
+        slickDivElement.not('.slick-initialized').slick();
 
         // reload slick carousel if it's first time clicking on arrow in any direction
         slickDivElement.find(".slick-arrow").on("click", function () {


### PR DESCRIPTION
Fixes problem with more than one slick getting created for same ID component. This bug can happen if there's duplicates on the data received by query builder with the same ID, or if the query builder gets resized and component re-rendered.

Closes #338 