### PR TITLE
#346 Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "file-loader": "^2.0.0",
     "file-saver": "^1.3.3",
     "google-maps": "^3.2.1",
-    "griddle-0.6-fork": "https://github.com/rodriguez-facundo/griddle.git",
+    "griddle-0.6-fork": "https://github.com/MetaCell/griddle.git#griddle-0.6-fork-react16",
     "griddle-react": "^1.13.1",
     "handlebars": "^4.0.5",
     "html2canvas": "^1.0.0-alpha.12",


### PR DESCRIPTION
Update package.json to use internal dependencies (namely, https://github.com/MetaCell/griddle/tree/griddle-0.6-fixes-react15 instead of https://github.com/rodriguez-facundo/griddle)
Closes #346 